### PR TITLE
Compatibility with Delphi (uses define MSWINDOWS instead of WINDOWS)

### DIFF
--- a/Source/DirectoryWatcherBuilder.pas
+++ b/Source/DirectoryWatcherBuilder.pas
@@ -1,5 +1,10 @@
 unit DirectoryWatcherBuilder;
 
+{$IFDEF MSWINDOWS}
+// compatibility with Delphi
+{$DEFINE WINDOWS}
+{$ENDIF}
+
 interface
 
 uses


### PR DESCRIPTION
The problem is, that IFDEF WINDOWS does not work when compiling with Delphi. So one can either add MSWINDOWS to the list inside the code or add the define WINDOWS, if MSWINDOWS is defined. I added the define, because I did not want to duplicate code and did not want to replace IFDEF by IF, because I do not know whether Lazarus understands this.